### PR TITLE
Correctry enable to work options.plugins (Fix #6)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -117,6 +117,10 @@ exports['default'] = function () {
 
             var _opts = _lodash2['default'].cloneDeep(opts);
 
+            if (opts.plugins) {
+              _opts.plugins = opts.plugins;
+            }
+
             if (opts.debug) {
               _opts.watch = false;
             }

--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,10 @@ export default function () {
 
            let _opts = _.cloneDeep(opts)
 
+           if (opts.plugins) {
+               _opts.plugins = opts.plugins
+           }
+
            if (opts.debug) {
              _opts.watch = false
            }


### PR DESCRIPTION
_.cloneDeep clones opts.plugins all entries as plain object.
but plugins instances must be keep it's owned .apply method for Tapable.apply.

This patch so re-assign `opts.plugins` into `_opts.plugins`.
