### PR TITLE
Now directories exclude from opts.entry when opts.entry not taken.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -106,7 +106,7 @@ exports['default'] = function () {
                 var entries = {};
 
                 files.forEach(function (file) {
-                  if (_fs2['default'].lstatSync(file).isDirectory()) {
+                  if (_fs2['default'].existsSync(file) && _fs2['default'].lstatSync(file).isDirectory()) {
                     return;
                   }
                   var name = _path2['default'].basename(file, _path2['default'].extname(file));

--- a/dist/index.js
+++ b/dist/index.js
@@ -16,6 +16,10 @@ var _path = require('path');
 
 var _path2 = _interopRequireDefault(_path);
 
+var _fs = require("fs");
+
+var _fs2 = _interopRequireDefault(_fs);
+
 var _chalk = require('chalk');
 
 var _chalk2 = _interopRequireDefault(_chalk);
@@ -102,6 +106,9 @@ exports['default'] = function () {
                 var entries = {};
 
                 files.forEach(function (file) {
+                  if (_fs2['default'].lstatSync(file).isDirectory()) {
+                    return;
+                  }
                   var name = _path2['default'].basename(file, _path2['default'].extname(file));
                   entries[name] = [];
                   entries[name].push(_path2['default'].join(process.cwd(), file));

--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ export default function () {
              let entries = {}
 
              files.forEach((file) => {
-               if (FileSystem.lstatSync(file).isDirectory()) {
+               if (FileSystem.existsSync(file) && FileSystem.lstatSync(file).isDirectory()) {
                  return
                }
                let name = path.basename(file, path.extname(file))

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import webpack from 'webpack'
 import path from 'path'
+import FileSystem from "fs"
 import chalk from 'chalk'
 import ProgressPlugin from 'webpack/lib/ProgressPlugin'
 import _ from 'lodash'
@@ -67,6 +68,9 @@ export default function () {
              let entries = {}
 
              files.forEach((file) => {
+               if (FileSystem.lstatSync(file).isDirectory()) {
+                 return
+               }
                let name = path.basename(file, path.extname(file))
                entries[name] = []
                entries[name].push(path.join(process.cwd(), file))


### PR DESCRIPTION
This patch fixes would have been included directories in opts.entry.
if opts.entry contains directory, webpack failed to build scripts.
At that moment, webpack throws below error.(The path are face down.)

```
ModuleNotFoundError: Module not found: Error: Cannot resolve 'file' or 'directory' <script_dir>/<directory_name> in <script_dir>
```
